### PR TITLE
Stable Rider strikes again: Remove slice_concat_ext feature use

### DIFF
--- a/src/clippy.rs
+++ b/src/clippy.rs
@@ -3,7 +3,6 @@
 extern crate rustc_serialize;
 
 use rustc_serialize::json::Json;
-use std::slice::SliceConcatExt;
 
 use std::process::Command;
 use std::path::Path;

--- a/src/github.rs
+++ b/src/github.rs
@@ -8,7 +8,6 @@ use std::thread;
 use tempdir::TempDir;
 use time::now_utc;
 
-use std::slice::SliceConcatExt;
 use redis::{Commands, PipelineCommands};
 
 use helpers::{setup_redis, log_redis, download_and_unzip};

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -20,7 +20,6 @@ use hyper::client::Client;
 
 use router::Router;
 
-use std::slice::SliceConcatExt;
 use redis::{Commands, Value};
 
 use helpers::{setup_redis, fetch, get_status_or,  local_redir, set_redis_cache};

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -23,7 +23,6 @@ use tempdir::TempDir;
 use time::now_utc;
 use zip::ZipArchive;
 
-use std::slice::SliceConcatExt;
 use redis::{Commands, RedisResult, PipelineCommands, Value};
 
 use iron::headers::{Location, CacheControl, CacheDirective};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,5 @@
 // **Run as an application, this is where execution starts.**
 
-// Features and macros need to be defined in the main entry point
-// of a project. In this case, we need a few macros as well as
-// the new slice-concat feature, a join on a vector (list) of strings.
-#![feature(slice_concat_ext)]
-
 // Further more we define our app dependencies on external crates.
 // First everything that is directly related to the iron framework
 // are using to build our web project on


### PR DESCRIPTION
SliceConcatExt is available on stable and on nightly without flags, just not in
places where the prelude is not used.
