### PR TITLE
Fix comment typo

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -25,7 +25,7 @@ use redis::{Commands, Value};
 use helpers::{setup_redis, fetch, get_status_or,  local_redir, set_redis_cache};
 use github::schedule_update as schedule_github_update;
 
-// The base URL for our badges. We aren't actually compiling them ourselfes,
+// The base URL for our badges. We aren't actually compiling them ourselves,
 // but are reusing the great shields.io service.
 static BADGE_URL_BASE: &'static str = "https://img.shields.io/badge/";
 


### PR DESCRIPTION
I noticed while enjoying the documentation of the clippy-service that the word 'ourselves' is misspelled. This change just fixes the typo. 

Thanks for all of the excellent work on the clippy-service documentation! I'm having an excellent time learning from it!

